### PR TITLE
chore: update plausible-client

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -18,7 +18,7 @@
     "date-and-time": "^3.6.0",
     "favicons": "^7.2.0",
     "mdast-util-from-markdown": "^2.0.2",
-    "plausible-client": "^1.0.0",
+    "plausible-client": "^2.0.0",
     "plausible-tracker": "^0.3.9",
     "reading-time": "^1.5.0",
     "unist-util-visit": "^5.0.0"

--- a/astro/src/components/BaseLayout/analytics/plausible.ts
+++ b/astro/src/components/BaseLayout/analytics/plausible.ts
@@ -1,67 +1,30 @@
 import {
 	enableAutoOutboundTracking,
 	enableAutoPageviews,
+	enableEngagementTracking,
+	enableLinkClicksCapture,
+	enableSessionScoring,
+	filters,
 	Plausible,
+	skipByFlag,
+	skipForHosts,
+	userId,
 } from 'plausible-client';
-
-import { isExternalUrl } from '../../../utils/links';
 
 const setupPlausible = () => {
 	const plausible = new Plausible({
 		domain: 'vitonsky.net',
 		apiHost: 'https://uxt.vitonsky.net',
-		filter(event, eventName) {
-			// Skip all events while development
-			if (location.hostname === 'localhost') {
-				console.warn('Analytics event is skipped, since run on localhost', event);
-				return false;
-			}
-
-			// Skip all events for users who don't want to be tracked
-			if (window.localStorage.plausible_ignore === 'true') return false;
-
-			// Skip internal links
-			if (eventName === 'Outbound Link: Click') {
-				const url = event.props?.url;
-
-				if (typeof url !== 'string' || !isExternalUrl(url)) return false;
-			}
-
-			// Pass all events otherwise
-			return true;
-		},
+		filter: filters(skipForHosts(['localhost']), skipByFlag('plausible_ignore')),
+		transform: userId(),
 	});
 
 	enableAutoPageviews(plausible);
-	enableAutoOutboundTracking(plausible);
+	enableSessionScoring(plausible);
+	enableEngagementTracking(plausible);
 
-	document.addEventListener(
-		'click',
-		(event) => {
-			// Iterate over all targets to find Anchor element and take its text
-			// We do it instead of handle target, since click may appear on nested element
-			for (const node of event.composedPath()) {
-				if (!(node instanceof HTMLAnchorElement)) continue;
-
-				const rawText = node.innerText.trim();
-				const textLimit = 120;
-				const text =
-					rawText.length <= textLimit
-						? rawText
-						: rawText.slice(0, textLimit) + '...';
-
-				plausible.trackEvent('linkClick', {
-					props: {
-						// Current location
-						location: location.toString(),
-						url: node.href,
-						text,
-					},
-				});
-			}
-		},
-		{ capture: true },
-	);
+	enableAutoOutboundTracking(plausible, { captureText: true });
+	enableLinkClicksCapture(plausible, { captureText: true });
 
 	return plausible;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
 				"date-and-time": "^3.6.0",
 				"favicons": "^7.2.0",
 				"mdast-util-from-markdown": "^2.0.2",
-				"plausible-client": "^1.0.0",
+				"plausible-client": "^2.0.0",
 				"plausible-tracker": "^0.3.9",
 				"reading-time": "^1.5.0",
 				"unist-util-visit": "^5.0.0"
@@ -8166,6 +8166,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/lodash": {
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"license": "MIT"
+		},
 		"node_modules/lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -10396,10 +10402,13 @@
 			}
 		},
 		"node_modules/plausible-client": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/plausible-client/-/plausible-client-1.1.0.tgz",
-			"integrity": "sha512-iP2Y31w3qgWvI1B+CIwq9jrkPyoU1t/IEiy+zWfK1wFTfUTwDbbugPC+EzxFsDwJaRceGZ1kame4Ug0u2SAhYw==",
-			"license": "MIT"
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/plausible-client/-/plausible-client-2.0.0.tgz",
+			"integrity": "sha512-P8y3wr42vo8adXCwO/gUiFZ3awIZ5sXLBNYsDwGPVPKv5jH8FguZ95nVibaRAoN2Lw0tQUAixs82j9EifhxS1w==",
+			"license": "MIT",
+			"dependencies": {
+				"lodash": "^4.17.23"
+			}
 		},
 		"node_modules/plausible-tracker": {
 			"version": "0.3.9",


### PR DESCRIPTION
In new version the plugins have been updated and now we can track scroll deepth and engagement measures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced analytics tracking with improved session scoring and engagement measurement capabilities.
  * Automatic detection and tracking of outbound links and user interactions.
  * Refined analytics data filtering with support for localhost exclusion and user opt-out preferences.

* **Chores**
  * Updated Plausible analytics client to version 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->